### PR TITLE
feat!: add optional license field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v2.0.0] - 2023-02-10
+### Added
+- Optional `license` input.
+### Changed
+- BREAKING: The action will fail if no `license` input is set and GitHub cannot determine the license automatically.
+
 ## [v1.0.2] - 2023-02-06
 ### Fixed
 - Escape quotes in summary

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: LuaRocks Upload
-        uses: nvim-neorocks/luarocks-tag-release@v1.0.2
+        uses: nvim-neorocks/luarocks-tag-release@v2.0.0
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
 ```
@@ -57,7 +57,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v1.0.2
+  uses: nvim-neorocks/luarocks-tag-release@v2.0.0
   with:
     dependencies: |
       plenary.nvim
@@ -73,7 +73,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v1.0.2
+  uses: nvim-neorocks/luarocks-tag-release@v2.0.0
   with:
     labels: |
       neovim
@@ -87,7 +87,7 @@ Example to specify additional directories:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v1.0.2
+  uses: nvim-neorocks/luarocks-tag-release@v2.0.0
   with:
     copy_directories: |
       doc
@@ -111,7 +111,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v1.0.2
+  uses: nvim-neorocks/luarocks-tag-release@v2.0.0
   with:
     detailed_description: |
       Publishes packages to LuaRocks when a git tag is pushed.
@@ -130,7 +130,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v1.0.2
+  uses: nvim-neorocks/luarocks-tag-release@v2.0.0
   with:
     build_type: "make"
 ```
@@ -146,10 +146,30 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v1.0.2
+  uses: nvim-neorocks/luarocks-tag-release@v2.0.0
   with:
     template: "/path/to/my/template.rockspec"
 ```
+
+### `license` (optional)
+
+The license used by this package.
+If not set (by default), this workflow will fetch the license SPDX ID from GitHub.
+If GitHub cannot detect the license automatically, you can set it here.
+
+Example:
+
+```yaml
+- name: LuaRocks Upload
+  uses: nvim-neorocks/luarocks-tag-release@v2.0.0
+  with:
+    license: "MIT"
+```
+> **Note**
+>
+> If GitHub can detect the license automatically, it will be displayed in your repository's About section.
+>
+> ![about](https://user-images.githubusercontent.com/12857160/218101570-b0605716-0457-47c1-ab2e-91d48a48881c.png)
 
 ## Limitations
 

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,13 @@ inputs:
     description: "Path to a rockspec template."
     required: true
     default: "/rockspec.template"
+  license:
+    description: |
+      The license SPDX identifier.
+      By default, it will be fetched from GitHub.
+      But sometimes, GitHub does not recognise it,
+      in which case LuaRocks will fall back to this one.
+    required: false
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -54,3 +61,4 @@ runs:
     - ${{ inputs.detailed_description }}
     - ${{ inputs.build_type }}
     - ${{ inputs.template }}
+    - ${{ inputs.license }}


### PR DESCRIPTION
BREAKING CHANGE: The action will now fail if the license cannot be determined using the GitHub API and the `license` field is not set.