### PR TITLE
feat: add make

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,11 +39,12 @@
         name = "luarocks-tag-release";
         runtimeInputs = with pkgs; [
           curl
-          zip
-          unzip
-          luarocks-tag-release-wrapped
-          lua51Packages.luarocks
+          gnumake
           lua51Packages.dkjson # Used by luarocks
+          lua51Packages.luarocks
+          luarocks-tag-release-wrapped
+          unzip
+          zip
         ];
 
         text = ''


### PR DESCRIPTION
luarocks supports different 'command' types, including make and cmake. I've intentionally left cmake out not to grow the closure size but make was required for nvim-treesitter release
