### PR TITLE
doc: mention make support in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v2.2.0] - 2023-02-24
+### Added
+- Added 'make' to build environment to fix the support for rockspecs of build type 'make'
+
 ## [v2.1.0] - 2023-02-17
 ### Added
 - Optional `version` input to support basic git workflows (#11).


### PR DESCRIPTION
luarocks supports different 'command' types, including make and cmake. I've intentionally left cmake out not to grow the closure size but make was required for nvim-treesitter release