### PR TITLE
feat: maintain mutable vX and vX.X tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: "Luarocks release"
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - 'v2.*.*'
 
 jobs:
   luarocks-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: "Luarocks release"
 on:
   push:
     tags:
-      - 'v2.*.*'
+      - 'v*.*.*'
 
 jobs:
   luarocks-release:
@@ -26,11 +26,3 @@ jobs:
           detailed_description: |
             This is not a real lua package.
             It exists for the purpose of testing the workflow.
-  update-latest-tag:
-    runs-on: ubuntu-latest
-    name: Update latest tag
-    steps:
-      - name: Run latest-tag
-        uses: EndBug/latest-tag@latest
-        with:
-          ref: "v2.x"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: "Luarocks release"
 on:
   push:
     tags:
-      - 'v*'
+      - 'v*.*.*'
 
 jobs:
   luarocks-release:
@@ -32,3 +32,5 @@ jobs:
     steps:
       - name: Run latest-tag
         uses: EndBug/latest-tag@latest
+        with:
+          ref: "2.x"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Run latest-tag
         uses: EndBug/latest-tag@latest
         with:
-          ref: "2.x"
+          ref: "v2.x"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: "Luarocks release"
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
 
 jobs:
   luarocks-release:
@@ -26,3 +26,9 @@ jobs:
           detailed_description: |
             This is not a real lua package.
             It exists for the purpose of testing the workflow.
+  update-latest-tag:
+    runs-on: ubuntu-latest
+    name: Update latest tag
+    steps:
+      - name: Run latest-tag
+        uses: EndBug/latest-tag@latest

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,0 +1,11 @@
+name: Update vX and vX.X tags on release
+
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  actions-tagger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Actions-R-Us/actions-tagger@latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for `latest` tag
 
 ## [v2.2.0] - 2023-02-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Support for `latest` tag
+- Maintain a `2.x` tag for the latest non-breaking release.
 
 ## [v2.2.0] - 2023-02-24
 ### Added
-- Added 'make' to build environment to fix the support for rockspecs of build type 'make'
+- Added 'make' to build environment to fix the support for rockspecs of build type 'make'.
 
 ## [v2.1.0] - 2023-02-17
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Maintain a `2.x` tag for the latest non-breaking release.
+- Maintain a `v2.x` tag for the latest non-breaking release.
 
 ## [v2.2.0] - 2023-02-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Maintain a `v2.x` tag for the latest non-breaking release.
+- Maintain `vX` and `vX.X` tags for the latest non-breaking releases.
 
 ## [v2.2.0] - 2023-02-24
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: LuaRocks Upload
-        uses: nvim-neorocks/luarocks-tag-release@2.x
+        uses: nvim-neorocks/luarocks-tag-release@v2.x
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
 ```
@@ -67,7 +67,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@2.x
+  uses: nvim-neorocks/luarocks-tag-release@v2.x
   with:
     dependencies: |
       plenary.nvim
@@ -83,7 +83,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@2.x
+  uses: nvim-neorocks/luarocks-tag-release@v2.x
   with:
     labels: |
       neovim
@@ -97,7 +97,7 @@ Example to specify additional directories:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@2.x
+  uses: nvim-neorocks/luarocks-tag-release@v2.x
   with:
     copy_directories: |
       doc
@@ -121,7 +121,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@2.x
+  uses: nvim-neorocks/luarocks-tag-release@v2.c
   with:
     detailed_description: |
       Publishes packages to LuaRocks when a git tag is pushed.
@@ -140,7 +140,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@2.x
+  uses: nvim-neorocks/luarocks-tag-release@v2.x
   with:
     build_type: "make"
 ```
@@ -156,7 +156,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@2.x
+  uses: nvim-neorocks/luarocks-tag-release@v2.x
   with:
     template: "/path/to/my/template.rockspec"
 ```
@@ -171,7 +171,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@2.x
+  uses: nvim-neorocks/luarocks-tag-release@v2.x
   with:
     license: "MIT"
 ```
@@ -211,7 +211,7 @@ jobs:
       - name: Get new commits
         run: echo "NEW_COMMIT_COUNT=$(git log --oneline --since '24 hours ago' | wc -l)" >> $GITHUB_ENV
       - name: LuaRocks Upload
-        uses: nvim-neorocks/luarocks-tag-release@2.x
+        uses: nvim-neorocks/luarocks-tag-release@v2.x
         if: ${{ env.NEW_COMMIT_COUNT > 0 }}
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ jobs:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
 ```
 
+> **Note**
+>
+> Use the `v2.x` tag to keep up with the latest releases, without breaking changes.
+
 ## Inputs
 
 The following optional inputs can be specified using `with:`

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v2.c
+  uses: nvim-neorocks/luarocks-tag-release@v2.x
   with:
     detailed_description: |
       Publishes packages to LuaRocks when a git tag is pushed.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: LuaRocks Upload
-        uses: nvim-neorocks/luarocks-tag-release@latest
+        uses: nvim-neorocks/luarocks-tag-release@2.x
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
 ```
@@ -67,7 +67,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@latest
+  uses: nvim-neorocks/luarocks-tag-release@2.x
   with:
     dependencies: |
       plenary.nvim
@@ -83,7 +83,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@latest
+  uses: nvim-neorocks/luarocks-tag-release@2.x
   with:
     labels: |
       neovim
@@ -97,7 +97,7 @@ Example to specify additional directories:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@latest
+  uses: nvim-neorocks/luarocks-tag-release@2.x
   with:
     copy_directories: |
       doc
@@ -121,7 +121,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@latest
+  uses: nvim-neorocks/luarocks-tag-release@2.x
   with:
     detailed_description: |
       Publishes packages to LuaRocks when a git tag is pushed.
@@ -140,7 +140,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@latest
+  uses: nvim-neorocks/luarocks-tag-release@2.x
   with:
     build_type: "make"
 ```
@@ -156,7 +156,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@latest
+  uses: nvim-neorocks/luarocks-tag-release@2.x
   with:
     template: "/path/to/my/template.rockspec"
 ```
@@ -171,7 +171,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@latest
+  uses: nvim-neorocks/luarocks-tag-release@2.x
   with:
     license: "MIT"
 ```
@@ -211,7 +211,7 @@ jobs:
       - name: Get new commits
         run: echo "NEW_COMMIT_COUNT=$(git log --oneline --since '24 hours ago' | wc -l)" >> $GITHUB_ENV
       - name: LuaRocks Upload
-        uses: nvim-neorocks/luarocks-tag-release@latest
+        uses: nvim-neorocks/luarocks-tag-release@2.x
         if: ${{ env.NEW_COMMIT_COUNT > 0 }}
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: LuaRocks Upload
-        uses: nvim-neorocks/luarocks-tag-release@v2.1.0
+        uses: nvim-neorocks/luarocks-tag-release@latest
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
 ```
@@ -67,7 +67,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v2.1.0
+  uses: nvim-neorocks/luarocks-tag-release@latest
   with:
     dependencies: |
       plenary.nvim
@@ -83,7 +83,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v2.1.0
+  uses: nvim-neorocks/luarocks-tag-release@latest
   with:
     labels: |
       neovim
@@ -97,7 +97,7 @@ Example to specify additional directories:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v2.1.0
+  uses: nvim-neorocks/luarocks-tag-release@latest
   with:
     copy_directories: |
       doc
@@ -121,7 +121,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v2.1.0
+  uses: nvim-neorocks/luarocks-tag-release@latest
   with:
     detailed_description: |
       Publishes packages to LuaRocks when a git tag is pushed.
@@ -140,7 +140,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v2.1.0
+  uses: nvim-neorocks/luarocks-tag-release@latest
   with:
     build_type: "make"
 ```
@@ -156,7 +156,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v2.1.0
+  uses: nvim-neorocks/luarocks-tag-release@latest
   with:
     template: "/path/to/my/template.rockspec"
 ```
@@ -171,7 +171,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v2.1.0
+  uses: nvim-neorocks/luarocks-tag-release@latest
   with:
     license: "MIT"
 ```
@@ -211,7 +211,7 @@ jobs:
       - name: Get new commits
         run: echo "NEW_COMMIT_COUNT=$(git log --oneline --since '24 hours ago' | wc -l)" >> $GITHUB_ENV
       - name: LuaRocks Upload
-        uses: nvim-neorocks/luarocks-tag-release@v2.1.0
+        uses: nvim-neorocks/luarocks-tag-release@latest
         if: ${{ env.NEW_COMMIT_COUNT > 0 }}
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -43,14 +43,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: LuaRocks Upload
-        uses: nvim-neorocks/luarocks-tag-release@v2.x
+        uses: nvim-neorocks/luarocks-tag-release@v2
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
 ```
 
 > **Note**
 >
-> Use the `v2.x` tag to keep up with the latest releases, without breaking changes.
+> Use the `v2` tag to keep up with the latest releases, without breaking changes.
 
 ## Inputs
 
@@ -71,7 +71,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v2.x
+  uses: nvim-neorocks/luarocks-tag-release@v2
   with:
     dependencies: |
       plenary.nvim
@@ -87,7 +87,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v2.x
+  uses: nvim-neorocks/luarocks-tag-release@v2
   with:
     labels: |
       neovim
@@ -101,7 +101,7 @@ Example to specify additional directories:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v2.x
+  uses: nvim-neorocks/luarocks-tag-release@v2
   with:
     copy_directories: |
       doc
@@ -125,7 +125,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v2.x
+  uses: nvim-neorocks/luarocks-tag-release@v2
   with:
     detailed_description: |
       Publishes packages to LuaRocks when a git tag is pushed.
@@ -144,7 +144,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v2.x
+  uses: nvim-neorocks/luarocks-tag-release@v2
   with:
     build_type: "make"
 ```
@@ -160,7 +160,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v2.x
+  uses: nvim-neorocks/luarocks-tag-release@v2
   with:
     template: "/path/to/my/template.rockspec"
 ```
@@ -175,7 +175,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v2.x
+  uses: nvim-neorocks/luarocks-tag-release@v2
   with:
     license: "MIT"
 ```
@@ -215,7 +215,7 @@ jobs:
       - name: Get new commits
         run: echo "NEW_COMMIT_COUNT=$(git log --oneline --since '24 hours ago' | wc -l)" >> $GITHUB_ENV
       - name: LuaRocks Upload
-        uses: nvim-neorocks/luarocks-tag-release@v2.x
+        uses: nvim-neorocks/luarocks-tag-release@v2
         if: ${{ env.NEW_COMMIT_COUNT > 0 }}
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}


### PR DESCRIPTION
This is easier to maintain.
Updating the version in the readme example snippets before every release is easy to forget.