### PR TITLE
fix: install to temp directory using --tree instead of --local

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,20 @@
+---
+name: "Test Luarocks install"
+on: pull_request
+
+jobs:
+  luarocks-release:
+    runs-on: ubuntu-latest
+    name: Test Luarocks install
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Test Luarocks install
+        uses: ./
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          dependencies: |
+            plenary.nvim
+          version: "0.0.0"
+          upload: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v2.2.0] - 2023-02-24
 ### Added
 - Added 'make' to build environment to fix the support for rockspecs of build type 'make'.
+### Fixed
+- Only install packages locally when running as non-root.
+  Fixes build failure in docker container.
 
 ## [v2.1.0] - 2023-02-17
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # LuaRocks tag release action
 
+[![Luarocks release](https://github.com/nvim-neorocks/luarocks-tag-release/actions/workflows/release.yml/badge.svg)](https://github.com/nvim-neorocks/luarocks-tag-release/actions/workflows/release.yml)
+
 Publishes packages to [LuaRocks](https://luarocks.org/) when a git tag is pushed.
 No need to add a rockspec to your repository for each release (or at all).
 

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,12 @@ inputs:
     description: "Path to a rockspec template."
     required: true
     default: "/rockspec.template"
+  upload:
+    description: |
+      Whether to upload to LuaRocks.
+      WARNING: This is an undocumented input, used internally for tests.
+      It is not part of the public API and may be removed without a major version bump.
+    default: true
   license:
     description: |
       The license SPDX identifier.
@@ -66,4 +72,5 @@ runs:
     - ${{ inputs.detailed_description }}
     - ${{ inputs.build_type }}
     - ${{ inputs.template }}
+    - ${{ inputs.upload }}
     - ${{ inputs.license }}


### PR DESCRIPTION
Fixes #27 

@teto

This also adds an `upload` input that allows us to test the first install step on each PR, and hopefully prevent future breakage.

I am keeping the input private so that we can remove it again if we find a way to do temporary test uploads to LuaRocks, as discussed in #26.