### PR TITLE
feat: ability to push from PRs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ inputs:
       Whether to upload to LuaRocks.
       WARNING: This is an undocumented input, used internally for tests.
       It is not part of the public API and may be removed without a major version bump.
-    default: true
+    default: "true"
   license:
     description: |
       The license SPDX identifier.
@@ -67,6 +67,14 @@ runs:
     - run: |
         nix profile install --accept-flake-config "${{ github.action_path }}#luarocks-tag-release-action"
       shell: bash
+    - run: |
+        pull_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+        echo "$GITHUB_EVENT_PATH"
+        cat "$GITHUB_EVENT_PATH"
+        echo "PR NBR: $pull_number"
+        which jq
+      shell: bash
+
     - run: luarocks-tag-release-action
       env:
         INPUT_NAME: ${{ inputs.name }}

--- a/bin/luarocks-tag-release-action.lua
+++ b/bin/luarocks-tag-release-action.lua
@@ -140,7 +140,6 @@ local is_tag = os.getenv('GITHUB_REF_TYPE') == 'tag'
 --
 local git_head_ref = os.getenv('GITHUB_HEAD_REF')
 local is_pr = git_head_ref ~= nil
-local git_ref
 -- = assert(os.getenv('GITHUB_REF_NAME'), 'GITHUB_REF_NAME not set')
 local specrev = '1'
 if not is_tag then

--- a/bin/luarocks-tag-release-action.lua
+++ b/bin/luarocks-tag-release-action.lua
@@ -89,6 +89,8 @@ end
 
 local license_input = os.getenv('INPUT_LICENSE')
 local template_input = os.getenv('INPUT_TEMPLATE')
+local package_name = getenv_or_err('INPUT_NAME')
+local package_version = getenv_or_err('INPUT_VERSION')
 
 local interpreters_input = os.getenv('INPUT_TEST_INTERPRETERS')
 ---@type lua_interpreter[]
@@ -112,8 +114,6 @@ local args = {
   github_repo = github_repo,
   repo_name = repo_name,
   github_server_url = github_server_url,
-  package_name = getenv_or_err('INPUT_NAME'),
-  package_version = getenv_or_err('INPUT_VERSION'),
   dependencies = parse_list_args(getenv_or_empty('INPUT_DEPENDENCIES')),
   labels = parse_list_args(getenv_or_empty('INPUT_LABELS')),
   copy_directories = parse_copy_directory_args(getenv_or_err('INPUT_COPY_DIRECTORIES')),
@@ -136,4 +136,9 @@ end
 
 local luarocks_tag_release = require('luarocks-tag-release')
 
-luarocks_tag_release(args)
+if getenv_or_empty('GITHUB_EVENT_NAME') == "pull_request" then
+  print("Running in a pull request, suffixing package name")
+  package_name = package_name.."pr-"..os.getenv("GITHUB_HEAD_REF")
+end
+
+luarocks_tag_release(package_name, package_version, args)

--- a/bin/luarocks-tag-release-action.lua
+++ b/bin/luarocks-tag-release-action.lua
@@ -138,7 +138,8 @@ local luarocks_tag_release = require('luarocks-tag-release')
 
 if getenv_or_empty('GITHUB_EVENT_NAME') == "pull_request" then
   print("Running in a pull request, suffixing package name")
-  package_name = package_name.."pr-"..os.getenv("GITHUB_HEAD_REF")
+  -- package_name = package_name.."-pr-"..os.getenv("GITHUB_HEAD_REF")
+  package_version = "pr-"..os.getenv("GITHUB_HEAD_REF")
 end
 
 luarocks_tag_release(package_name, package_version, args)

--- a/bin/luarocks-tag-release-action.lua
+++ b/bin/luarocks-tag-release-action.lua
@@ -136,10 +136,24 @@ end
 
 local luarocks_tag_release = require('luarocks-tag-release')
 
+local is_tag = os.getenv('GITHUB_REF_TYPE') == 'tag'
+--
+local git_head_ref = os.getenv('GITHUB_HEAD_REF')
+local is_pr = git_head_ref ~= nil
+local git_ref
+-- = assert(os.getenv('GITHUB_REF_NAME'), 'GITHUB_REF_NAME not set')
+local specrev = '1'
+if not is_tag then
+  print('Publishing an untagged release.')
+  -- git_ref = assert(os.getenv('GITHUB_SHA'), 'GITHUB_SHA not set')
+end
+if is_pr then
+  specrev = assert(os.getenv("GITHUB_RUN_ATTEMPT"), "GITHUB_RUN_ATTEMPT not set")
+end
 if getenv_or_empty('GITHUB_EVENT_NAME') == "pull_request" then
   print("Running in a pull request, suffixing package name")
   -- package_name = package_name.."-pr-"..os.getenv("GITHUB_HEAD_REF")
   package_version = "pr-"..os.getenv("GITHUB_HEAD_REF")
 end
 
-luarocks_tag_release(package_name, package_version, args)
+luarocks_tag_release(package_name, package_version, specrev, args)

--- a/lua/luarocks-tag-release.lua
+++ b/lua/luarocks-tag-release.lua
@@ -23,29 +23,15 @@
 
 ---@param package_name string
 ---@param package_version string
+---@param specrev number the version of the rockspec
 ---@param args Args
-local function luarocks_tag_release(package_name, package_version, args)
+local function luarocks_tag_release(package_name, package_version, specrev, args)
   -- version in format 3.0 must follow the format '[%w.]+-[%d]+'
   local modrev = string.gsub(package_version, 'v', '')
 
-  local is_tag = os.getenv('GITHUB_REF_TYPE') == 'tag'
-  --
-  local git_head_ref = os.getenv('GITHUB_HEAD_REF')
-  local is_pr = git_head_ref ~= nil
-  local git_ref
-  -- = assert(os.getenv('GITHUB_REF_NAME'), 'GITHUB_REF_NAME not set')
-  local specrev = '1'
   local archive_dir_suffix = args.ref_type == 'tag' and modrev or args.git_ref
-  if not is_tag then
-    print('Publishing an untagged release.')
-    git_ref = assert(os.getenv('GITHUB_SHA'), 'GITHUB_SHA not set')
-    archive_dir_suffix = git_ref
-  end
-  if is_pr then
-    specrev = assert(os.getenv("GITHUB_RUN_ATTEMPT"), "GITHUB_RUN_ATTEMPT not set")
-  end
 
-  local target_rockspec_file = package_name .. '-' .. modrev .. '-'.. specrev .. '.rockspec'
+  local target_rockspec_file = package_name .. '-' .. modrev .. '-'.. tostring(specrev) .. '.rockspec'
 
   ---@param filename string
   ---@return string? content

--- a/lua/luarocks-tag-release.lua
+++ b/lua/luarocks-tag-release.lua
@@ -23,7 +23,7 @@
 
 ---@param package_name string
 ---@param package_version string
----@param specrev number the version of the rockspec
+---@param specrev string the version of the rockspec
 ---@param args Args
 local function luarocks_tag_release(package_name, package_version, specrev, args)
   -- version in format 3.0 must follow the format '[%w.]+-[%d]+'
@@ -31,7 +31,7 @@ local function luarocks_tag_release(package_name, package_version, specrev, args
 
   local archive_dir_suffix = args.ref_type == 'tag' and modrev or args.git_ref
 
-  local target_rockspec_file = package_name .. '-' .. modrev .. '-'.. tostring(specrev) .. '.rockspec'
+  local target_rockspec_file = package_name .. '-' .. modrev .. '-' .. specrev .. '.rockspec'
 
   ---@param filename string
   ---@return string? content
@@ -122,7 +122,7 @@ local function luarocks_tag_release(package_name, package_version, specrev, args
     print(stdout)
     cmd = 'luarocks upload ' .. target_rockspec_file .. ' --api-key $LUAROCKS_API_KEY'
     if test_release then
-      cmd = cmd.." --force"
+      cmd = cmd .. ' --force'
     end
     print('UPLOAD: ' .. cmd)
     stdout, _ = execute(cmd)
@@ -205,9 +205,9 @@ local function luarocks_tag_release(package_name, package_version, specrev, args
       .. args.git_ref
       .. '.'
   )
-  print("is_pr", is_pr, "event name", os.getenv('GITHUB_EVENT_NAME'), "head:", os.getenv('GITHUB_HEAD_REF'))
+  print('is_pr', is_pr, 'event name', os.getenv('GITHUB_EVENT_NAME'), 'head:', os.getenv('GITHUB_HEAD_REF'))
   if is_pr then
-    print("Running from Pull Request, overriding existing releases enabled")
+    print('Running from Pull Request, overriding existing releases enabled')
   end
   local rockspec = content
     :gsub('$git_ref', args.git_ref)

--- a/lua/luarocks-tag-release.lua
+++ b/lua/luarocks-tag-release.lua
@@ -25,14 +25,14 @@
 ---@param package_version string
 ---@param args Args
 local function luarocks_tag_release(package_name, package_version, args)
-  local modversion = string.gsub(package_version, 'v', '')
+  local modrev = string.gsub(package_version, 'v', '')
 
   local is_tag = os.getenv('GITHUB_REF_TYPE') == 'tag'
   --
   local git_head_ref = os.getenv('GITHUB_HEAD_REF')
   local is_pr = git_head_ref ~= nil
   local git_ref = assert(os.getenv('GITHUB_REF_NAME'), 'GITHUB_REF_NAME not set')
-  local modrev = '1'
+  local specrev = '1'
   local archive_dir_suffix = args.ref_type == 'tag' and modrev or args.git_ref
   if not is_tag then
     print('Publishing an untagged release.')
@@ -40,10 +40,10 @@ local function luarocks_tag_release(package_name, package_version, args)
     archive_dir_suffix = git_ref
   end
   if is_pr then
-    modrev = git_ref
+    specrev = git_ref
   end
 
-  local target_rockspec_file = package_name .. '-' .. modversion .. '-'.. modrev .. '.rockspec'
+  local target_rockspec_file = package_name .. '-' .. modrev .. '-'.. specrev .. '.rockspec'
 
   ---@param filename string
   ---@return string? content
@@ -224,6 +224,7 @@ local function luarocks_tag_release(package_name, package_version, args)
   local rockspec = content
     :gsub('$git_ref', args.git_ref)
     :gsub('$modrev', modrev)
+    :gsub('$specrev', specrev)
     :gsub('$repo_url', repo_url)
     :gsub('$archive_dir_suffix', archive_dir_suffix)
     :gsub('$package', package_name)

--- a/lua/luarocks-tag-release.lua
+++ b/lua/luarocks-tag-release.lua
@@ -25,13 +25,15 @@
 ---@param package_version string
 ---@param args Args
 local function luarocks_tag_release(package_name, package_version, args)
+  -- version in format 3.0 must follow the format '[%w.]+-[%d]+'
   local modrev = string.gsub(package_version, 'v', '')
 
   local is_tag = os.getenv('GITHUB_REF_TYPE') == 'tag'
   --
   local git_head_ref = os.getenv('GITHUB_HEAD_REF')
   local is_pr = git_head_ref ~= nil
-  local git_ref = assert(os.getenv('GITHUB_REF_NAME'), 'GITHUB_REF_NAME not set')
+  local git_ref
+  -- = assert(os.getenv('GITHUB_REF_NAME'), 'GITHUB_REF_NAME not set')
   local specrev = '1'
   local archive_dir_suffix = args.ref_type == 'tag' and modrev or args.git_ref
   if not is_tag then
@@ -40,7 +42,7 @@ local function luarocks_tag_release(package_name, package_version, args)
     archive_dir_suffix = git_ref
   end
   if is_pr then
-    specrev = git_ref
+    specrev = assert(os.getenv("GITHUB_RUN_ATTEMPT"), "GITHUB_RUN_ATTEMPT not set")
   end
 
   local target_rockspec_file = package_name .. '-' .. modrev .. '-'.. specrev .. '.rockspec'

--- a/resources/rockspec.template
+++ b/resources/rockspec.template
@@ -1,6 +1,6 @@
 local git_ref = '$git_ref'
 local modrev = '$modrev'
-local specrev = '-1'
+local specrev = '$specrev'
 
 local repo_url = '$repo_url'
 

--- a/resources/rockspec.template
+++ b/resources/rockspec.template
@@ -6,7 +6,7 @@ local repo_url = '$repo_url'
 
 rockspec_format = '3.0'
 package = '$package'
-version = modrev .. specrev
+version = modrev ..'-'.. specrev
 
 description = {
   summary = '$summary',


### PR DESCRIPTION
the ability to test from a PR that the rockspec is correctly uploaded to luarocks.org and can be installed from then is great to have.

now the install would probably need a `--dev` if the package doesn't belong to the root manifest.