### PR TITLE
feat: update neorocks flake input before running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v5.2.0] -
+### Added
+- Ensure `neovim` and `neovim-nightly` lua interpreters for `luarocks test` are
+  up-to-date before running the action.
+
 ## [v5.1.1] - 2023-07-17
 ### Fixed
 - Use `GITHUB_EVENT_PATH` to get extra repo info

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,8 @@ runs:
   steps:
     - uses: cachix/install-nix-action@v22
     - run: |
+        # Ensure we are using the latest neorocks (for luarocks test)
+        nix flake lock --update-input neorocks
         nix profile install --accept-flake-config "${{ github.action_path }}#luarocks-tag-release-action"
       shell: bash
 


### PR DESCRIPTION
Closes #69.

### Summary

Updaes the `neorocks` input before running to make sure that `luarocks test` uses up-to-date neovim and neovim-nightly as lua interpreters (`neorocks` updats them daily).

### Alternative solution

Automatically update flake.lock daily and publish a new release with a patch version bump.

### pros

- No need to keep bumping patch versions when updating the `neorocks` flake input.
- With the alternative approach,, we have to be edit releases manually using the GitHub GUI, to publish them to the marketplace (see #21).
  - Maybe we don't have to do this if the mutable `vX` tag gets updated without a marketplace release.

### cons

- Breaks reproducibility.
  - I'm not sure if we care about this, since most people will likely be using mutable `vX` tags.
  - We could mitigate this by adding an optional input that disables this behaviour.
- Can update more dependencies than just neovim, e.g. luarocks.
  