### PR TITLE
chore: print generated rockspec filename in logs

### DIFF
--- a/lua/luarocks-tag-release.lua
+++ b/lua/luarocks-tag-release.lua
@@ -59,7 +59,7 @@ local function luarocks_tag_release(package_name, package_version, specrev, args
   ---@param content string
   ---@return nil
   local function write_file(filename, content)
-    local outfile = assert(io.open(filename, 'w'), 'Could not create ' .. filenane .. '.')
+    local outfile = assert(io.open(filename, 'w'), 'Could not create ' .. filename .. '.')
     outfile:write(content)
     outfile:close()
   end

--- a/lua/luarocks-tag-release.lua
+++ b/lua/luarocks-tag-release.lua
@@ -55,10 +55,11 @@ local function luarocks_tag_release(package_name, package_version, specrev, args
     return false
   end
 
+  ---@param filename string
   ---@param content string
   ---@return nil
-  local function write_file(content)
-    local outfile = assert(io.open(rockspec_file_path, 'w'), 'Could not create ' .. rockspec_file_path .. '.')
+  local function write_file(filename, content)
+    local outfile = assert(io.open(filename, 'w'), 'Could not create ' .. file_path .. '.')
     outfile:write(content)
     outfile:close()
   end
@@ -233,7 +234,7 @@ local function luarocks_tag_release(package_name, package_version, specrev, args
   print(rockspec)
   print('========================================================================================')
 
-  write_file(rockspec)
+  write_file(rockspec_file_path, rockspec)
   if file_exists('.busted') then
     for _, interpreter in pairs(args.luarocks_test_interpreters) do
       luarocks_test(interpreter)

--- a/lua/luarocks-tag-release.lua
+++ b/lua/luarocks-tag-release.lua
@@ -59,7 +59,7 @@ local function luarocks_tag_release(package_name, package_version, specrev, args
   ---@param content string
   ---@return nil
   local function write_file(filename, content)
-    local outfile = assert(io.open(filename, 'w'), 'Could not create ' .. file_path .. '.')
+    local outfile = assert(io.open(filename, 'w'), 'Could not create ' .. filenane .. '.')
     outfile:write(content)
     outfile:close()
   end

--- a/lua/luarocks-tag-release.lua
+++ b/lua/luarocks-tag-release.lua
@@ -229,7 +229,7 @@ local function luarocks_tag_release(package_name, package_version, specrev, args
     :gsub('$repo_name', args.repo_name)
 
   print('')
-  print('Generated rockspec:')
+  print('Generated ' .. rockspec_file_path .. ':')
   print('========================================================================================')
   print(rockspec)
   print('========================================================================================')


### PR DESCRIPTION
Minor code cleanups:

- fix `write_file` function to match the function name. Alternatively we could rename it to `write_rockspec_file`.
- print the name of the generated rockspec file in the logs.