### PR TITLE
fix: print `luarocks test` `stdout` and `stderr` to workflow log

### DIFF
--- a/lua/ltr/os.lua
+++ b/lua/ltr/os.lua
@@ -33,8 +33,9 @@ end
 
 ---@param cmd string
 ---@param on_failure fun(error_msg:string)?
+---@param verbose boolean|nil If true, will print stdout and stderr
 ---@return string stdout, string stderr
-function OS.execute(cmd, on_failure)
+function OS.execute(cmd, on_failure, verbose)
   on_failure = on_failure or error
   local exec_out = 'exec_out.txt'
   local exec_err = 'exec_err.txt'
@@ -44,6 +45,9 @@ function OS.execute(cmd, on_failure)
   local stderr = OS.read_file(exec_err) or ''
   if exit_code ~= 0 then
     on_failure(cmd .. ' FAILED\nexit code: ' .. exit_code .. '\nstdout: ' .. stdout .. '\nstderr: ' .. stderr)
+  elseif verbose then
+    print(stdout)
+    print(stderr)
   end
   return stdout, stderr
 end

--- a/lua/luarocks-tag-release.lua
+++ b/lua/luarocks-tag-release.lua
@@ -42,7 +42,7 @@ local function luarocks_tag_release(package_name, package_version, specrev, args
     OS.execute('luarocks config --scope project lua_interpreter ' .. interpreter)
     print('Done.')
     print('Running tests...')
-    OS.execute('luarocks test')
+    OS.execute('luarocks test', error, true)
     OS.execute('rm -r .luarocks luarocks', print)
   end
 


### PR DESCRIPTION
Fixes #82 