### PR TITLE
fix(parser): add missing `after` directory in the Neovim plugin dirs list

### DIFF
--- a/lua/ltr/parser.lua
+++ b/lua/ltr/parser.lua
@@ -14,6 +14,7 @@ end
 ---@param copy_directories string[] List of directories
 local function insert_neovim_plugin_dirs(copy_directories)
   local neovim_plugin_dirs = {
+    'after',
     'autoload',
     'colors',
     'compiler',

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -28,6 +28,7 @@ describe('Parser', function()
       third
     ]])
     assert.same(result, {
+      'after',
       'autoload',
       'colors',
       'compiler',


### PR DESCRIPTION
This should fix problems with Neovim plugins like [rocks-config.nvim](https://github.com/nvim-neorocks/rocks-config.nvim), which now uses the `after/plugin` directory instead of `plugin`.

The rockspec generated without this patch looks like this, which is why the file necessary for it to work is not installed (see the `copy_directories` table).

![image](https://github.com/nvim-neorocks/luarocks-tag-release/assets/36456999/60df7dbc-f728-4c71-90eb-8467f5ea1e5e)