### PR TITLE
feat: do not fail on already existing rocks, add `fail_on_duplicate` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,12 @@ Example:
     specrev: "${{ env.SPECREV }}"
 ```
 
+### `fail_on_duplicate` (optional)
+
+When set to `true` will cause the workflow to fail with an error if the rock already exists on the server.
+By default, if the rock already exists with a given version, the workflow will do nothing and fall back to other tasks
+instead (e.g. running tests).
+
 ### `extra_luarocks_args`
 
 Extra args to pass to the luarocks command.

--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,10 @@ inputs:
       Extra args to pass to the luarocks command.
       For example: "CURL_DIR=/usr/include/x86_64-linux-gnu/"
     required: false
+  fail_on_duplicate:
+    description: |
+      Whether to fail if the rock's version has already been published to `luarocks.org`.
+    required: false
 runs:
   using: "composite"
   steps:
@@ -92,5 +96,6 @@ runs:
         INPUT_LICENSE: ${{ inputs.license }}
         INPUT_TEST_INTERPRETERS: ${{ inputs.test_interpreters }}
         INPUT_EXTRA_LUAROCKS_ARGS: ${{ inputs.extra_luarocks_args }}
+        INPUT_FAIL_ON_DUPLICATE: ${{ inputs.fail_on_duplicate }}
         RUNNER_DEBUG: ${{ runner.debug }}
       shell: bash

--- a/bin/luarocks-tag-release-action.lua
+++ b/bin/luarocks-tag-release-action.lua
@@ -59,6 +59,7 @@ local args = {
   ref_type = os.getenv('GITHUB_REF_TYPE_OVERRIDE') or getenv_or_err('GITHUB_REF_TYPE'),
   git_ref = os.getenv('GITHUB_REF_NAME_OVERRIDE') or getenv_or_err('GITHUB_REF_NAME'),
   is_debug = os.getenv('RUNNER_DEBUG') == '1',
+  fail_on_duplicate = getenv_or_empty('INPUT_FAIL_ON_DUPLICATE') == 'true',
 }
 
 local function get_github_sha()


### PR DESCRIPTION
This pull request adds a `fail_on_duplicate` flag to the github action (set to `false` by default). This will prevent the workflow from failing if the rock already exists on the server.

This should greatly simplify the workflows people use for releasing their plugin, as now the workflow should be able to run every time a commit is made to a repository.

Fixes #377.

Things to do:
- [x] Add mention of the option in the README