### PR TITLE
feat!: drop support for running tests in favour of nvim-busted-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ No need to add a rockspec to your repository for each release (or at all).
 - Tests a local installation from the rockspec file before uploading.
 - Uploads the package to LuaRocks.
 - Tests the installation of the uploaded package.
-- Runs [`luarocks test`](https://github.com/luarocks/luarocks/wiki/test)
-  with lua, neovim 0.9 and/or neovim-nightly as the interpreter.
 
 ## Prerequisites
 
@@ -75,14 +73,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: LuaRocks Upload
-        uses: nvim-neorocks/luarocks-tag-release@v6
+        uses: nvim-neorocks/luarocks-tag-release@v7
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
 ```
 
 > [!NOTE]
 >
-> Use the `v6` tag to keep up with the latest releases, without breaking changes.
+> Use the `v7` tag to keep up with the latest releases, without breaking changes.
 
 ## Inputs
 
@@ -103,7 +101,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v6
+  uses: nvim-neorocks/luarocks-tag-release@v7
   with:
     dependencies: |
       plenary.nvim
@@ -119,7 +117,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v6
+  uses: nvim-neorocks/luarocks-tag-release@v7
   with:
     test_dependencies: |
       luaunit
@@ -134,50 +132,11 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v6
+  uses: nvim-neorocks/luarocks-tag-release@v7
   with:
     labels: |
       neovim
 ```
-
-### `test_interpreters`
-
-> [!WARNING]
->
-> DEPRECATED! Use [nvim-busted-action](https://github.com/marketplace/actions/nvim-busted-action)
-> or [lua-busted](https://github.com/marketplace/actions/lua-busted) for tests instead!
->
-> This will be removed completely in a later release.
-
-Lua interpreters to run `luarocks test` with.
-If set to an empty string (default), or no [.busted file](https://lunarmodules.github.io/busted/#usage)
-is present, no tests will be run.
-
-Supported interpreters:
-
-- `neovim-stable` - With access to the [Neovim 0.9 Lua API](https://neovim.io/doc/user/lua.html).
-- `neovim-nightly` - With access to the Neovim nightly Lua API.
-- `lua` - Plain luajit
-
-Example:
-
-```yaml
-- name: LuaRocks Test and Upload
-  uses: nvim-neorocks/luarocks-tag-release@v6
-  with:
-    test_interpreters: |
-      neovim-stable
-      neovim-nightly
-```
-
-> [!NOTE]
->
-> For reproducible builds with recent versions of Neovim,
-> we recommend **not** to use the latest stable tag,
-> but instead to use [Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-github-dependabot-version-updates)
-> to manage version updates.
-> For convenience, you can [auto-approve](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#approve-a-pull-request)
-> the pull request.
 
 ### `copy_directories`
 
@@ -189,7 +148,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v6
+  uses: nvim-neorocks/luarocks-tag-release@v7
   with:
     copy_directories: |
       {{ neovim.plugin.dirs }}
@@ -243,7 +202,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v6
+  uses: nvim-neorocks/luarocks-tag-release@v7
   with:
     detailed_description: |
       Publishes packages to LuaRocks when a git tag is pushed.
@@ -262,7 +221,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v6
+  uses: nvim-neorocks/luarocks-tag-release@v7
   with:
     template: "/path/to/my/template.rockspec"
 ```
@@ -277,7 +236,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v6
+  uses: nvim-neorocks/luarocks-tag-release@v7
   with:
     license: "MIT"
 ```
@@ -326,7 +285,7 @@ jobs:
       - name: Get new commits
         run: echo "NEW_COMMIT_COUNT=$(git log --oneline --since '24 hours ago' | wc -l)" >> $GITHUB_ENV
       - name: LuaRocks Upload
-        uses: nvim-neorocks/luarocks-tag-release@v6
+        uses: nvim-neorocks/luarocks-tag-release@v7
         if: ${{ env.NEW_COMMIT_COUNT > 0 }}
         env:
           LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
@@ -355,7 +314,7 @@ Example:
 
 ```yaml
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v6
+  uses: nvim-neorocks/luarocks-tag-release@v7
   with:
     version: "scm"
     # Add logic or determining if the specrev needs to be incremented
@@ -379,7 +338,7 @@ Example:
 - run: |
     sudo apt-get install -y libcurl4-openssl-dev
 - name: LuaRocks Upload
-  uses: nvim-neorocks/luarocks-tag-release@v6
+  uses: nvim-neorocks/luarocks-tag-release@v7
   with:
     extra_luarocks_args: |
       CURL_INCDIR=/usr/include/x86_64-linux-gnu

--- a/action.yml
+++ b/action.yml
@@ -55,11 +55,6 @@ inputs:
       But sometimes, GitHub does not recognise it,
       in which case LuaRocks will fall back to this one.
     required: false
-  test_interpreters:
-    description: |
-      DEPRECATED! Use nvim-neorocks/nvim-busted-action for tests instead!
-    required: false
-    default: ""
   extra_luarocks_args:
     description: |
       Extra args to pass to the luarocks command.
@@ -90,7 +85,6 @@ runs:
         INPUT_DETAILED_DESCRIPTION: ${{ inputs.detailed_description }}
         INPUT_TEMPLATE: ${{ inputs.template }}
         INPUT_LICENSE: ${{ inputs.license }}
-        INPUT_TEST_INTERPRETERS: ${{ inputs.test_interpreters }}
         INPUT_EXTRA_LUAROCKS_ARGS: ${{ inputs.extra_luarocks_args }}
         INPUT_FAIL_ON_DUPLICATE: ${{ inputs.fail_on_duplicate }}
         RUNNER_DEBUG: ${{ runner.debug }}

--- a/bin/luarocks-tag-release-action.lua
+++ b/bin/luarocks-tag-release-action.lua
@@ -33,17 +33,6 @@ local package_name = getenv_or_err('INPUT_NAME')
 ---@type string | nil
 local package_version = is_pull_request and '0.0.0' or os.getenv('INPUT_VERSION')
 
-local interpreters_input = os.getenv('INPUT_TEST_INTERPRETERS')
-if interpreters_input ~= '' then
-  print([[
-WARNING: The test_interpreters input is deprecated and will be removed in a later release.
-Use nvim-neorocks/nvim-busted-action or lua-busted instead.
-  - https://github.com/marketplace/actions/nvim-busted-action
-  - https://github.com/marketplace/actions/lua-busted
-]])
-end
-local test_interpreters = Parser.parse_interpreter_input(interpreters_input)
-
 ---@type Args
 local args = {
   github_repo = github_repo,
@@ -61,7 +50,6 @@ local args = {
     or action_path .. '/resources/rockspec.template',
   upload = not is_pull_request,
   license = license_input ~= '' and license_input or nil,
-  luarocks_test_interpreters = test_interpreters,
   extra_luarocks_args = Parser.parse_list_args(getenv_or_empty('INPUT_EXTRA_LUAROCKS_ARGS')),
   github_event_path = getenv_or_err('GITHUB_EVENT_PATH'),
   ref_type = os.getenv('GITHUB_REF_TYPE_OVERRIDE') or getenv_or_err('GITHUB_REF_TYPE'),

--- a/flake.lock
+++ b/flake.lock
@@ -16,132 +16,6 @@
         "type": "github"
       }
     },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_4": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_5": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1717285511,
-        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_2": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "neorocks-nix",
-          "neovim-nightly",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1717285511,
-        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_3": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "neorocks-nix",
-          "neovim-nightly",
-          "hercules-ci-effects",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1712014858,
-        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
-        "type": "github"
-      },
-      "original": {
-        "id": "flake-parts",
-        "type": "indirect"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -162,46 +36,19 @@
     },
     "git-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat",
         "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1718825512,
-        "narHash": "sha256-nz7idS/SZWcTUGJ+lOFL+eJayrL/LpkUiy7+FxThAh4=",
+        "lastModified": 1718879355,
+        "narHash": "sha256-RTyqP4fBX2MdhNuMP+fnR3lIwbdtXhyj7w7fwtvgspc=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "97c0dc865fe9a062c5970f4bcf55bb9e6028bcf5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "git-hooks_2": {
-      "inputs": {
-        "flake-compat": "flake-compat_4",
-        "gitignore": "gitignore_2",
-        "nixpkgs": [
-          "neorocks-nix",
-          "neovim-nightly",
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": [
-          "neorocks-nix",
-          "neovim-nightly",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1717664902,
-        "narHash": "sha256-7XfBuLULizXjXfBYy/VV+SpYMHreNRHk9nKMsm1bgb4=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "cc4d466cb1254af050ff7bdf47f6d404a7c646d1",
+        "rev": "8cd35b9496d21a6c55164d8547d9d5280162b07a",
         "type": "github"
       },
       "original": {
@@ -213,7 +60,6 @@
     "gitignore": {
       "inputs": {
         "nixpkgs": [
-          "neorocks-nix",
           "git-hooks",
           "nixpkgs"
         ]
@@ -229,274 +75,46 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "gitignore_2": {
-      "inputs": {
-        "nixpkgs": [
-          "neorocks-nix",
-          "neovim-nightly",
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "gitignore_3": {
-      "inputs": {
-        "nixpkgs": [
-          "pre-commit-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "hercules-ci-effects": {
-      "inputs": {
-        "flake-parts": "flake-parts_3",
-        "nixpkgs": [
-          "neorocks-nix",
-          "neovim-nightly",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1718018037,
-        "narHash": "sha256-03rLBd/lKecgaKz0j5ESUf9lDn5R0SJatZTKLL5unWE=",
-        "owner": "hercules-ci",
-        "repo": "hercules-ci-effects",
-        "rev": "0ab08b23ce3c3f75fe9a5598756b6fb8bcf0b414",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "hercules-ci-effects",
-        "type": "github"
-      }
-    },
-    "neorocks-nix": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-parts": "flake-parts",
-        "git-hooks": "git-hooks",
-        "neovim-nightly": "neovim-nightly",
-        "nixpkgs": "nixpkgs_3"
-      },
-      "locked": {
-        "lastModified": 1718861071,
-        "narHash": "sha256-892vV7zK4fgu6ayrbilZvBQyEHYjEPv1jcknrPQa58Q=",
-        "owner": "mrcjkb",
-        "repo": "neorocks-nix",
-        "rev": "6ee066aeaa0cfb0b478d30a81b65ac1b1f154392",
-        "type": "github"
-      },
-      "original": {
-        "owner": "mrcjkb",
-        "repo": "neorocks-nix",
-        "type": "github"
-      }
-    },
-    "neovim-nightly": {
-      "inputs": {
-        "flake-compat": "flake-compat_3",
-        "flake-parts": "flake-parts_2",
-        "git-hooks": "git-hooks_2",
-        "hercules-ci-effects": "hercules-ci-effects",
-        "neovim-src": "neovim-src",
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1718775905,
-        "narHash": "sha256-1o1A/esIIRAkXfd20TmYU6jJTF3YHUlcAUNezQnizM4=",
-        "owner": "nix-community",
-        "repo": "neovim-nightly-overlay",
-        "rev": "42261b7220526fb7fd72912ab3e647019e1d1148",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "neovim-nightly-overlay",
-        "type": "github"
-      }
-    },
-    "neovim-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1718749922,
-        "narHash": "sha256-DAx1WRYBHL9AkPKrJP0aBEtvoH3VgAXJTfALRlkD8ds=",
-        "owner": "neovim",
-        "repo": "neovim",
-        "rev": "a2d510e1015d57f28ab20c5d2897527cae15b9c4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "neovim",
-        "repo": "neovim",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710765496,
-        "narHash": "sha256-p7ryWEeQfMwTB6E0wIUd5V2cFTgq+DRRBz2hYGnJZyA=",
-        "owner": "NixOS",
+        "lastModified": 1718606988,
+        "narHash": "sha256-pmjP5ePc1jz+Okona3HxD7AYT0wbrCwm9bXAlj08nDM=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e367f7a1fb93137af22a3908f00b9a35e2d286a7",
+        "rev": "38d3352a65ac9d621b0cd3074d3bef27199ff78f",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
+        "owner": "nixos",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
-      }
-    },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1717284937,
-        "narHash": "sha256-lIbdfCsf8LMFloheeE6N31+BMIeixqyQWbSr2vk79EQ=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
       }
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1710695816,
-        "narHash": "sha256-3Eh7fhEID17pv9ZxrPwCLfqXnYP006RKzSs0JptsN84=",
+        "lastModified": 1718447546,
+        "narHash": "sha256-JHuXsrC9pr4kA4n7LuuPfWFJUVlDBVJ1TXDVpHEuUgM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "614b4613980a522ba49f0d194531beddbb7220d3",
+        "rev": "842253bf992c3a7157b67600c2857193f126563a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixos-23.11",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-stable_2": {
-      "locked": {
-        "lastModified": 1710695816,
-        "narHash": "sha256-3Eh7fhEID17pv9ZxrPwCLfqXnYP006RKzSs0JptsN84=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "614b4613980a522ba49f0d194531beddbb7220d3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-23.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1718606988,
-        "narHash": "sha256-pmjP5ePc1jz+Okona3HxD7AYT0wbrCwm9bXAlj08nDM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "38d3352a65ac9d621b0cd3074d3bef27199ff78f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1718606988,
-        "narHash": "sha256-pmjP5ePc1jz+Okona3HxD7AYT0wbrCwm9bXAlj08nDM=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "38d3352a65ac9d621b0cd3074d3bef27199ff78f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1718606988,
-        "narHash": "sha256-pmjP5ePc1jz+Okona3HxD7AYT0wbrCwm9bXAlj08nDM=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "38d3352a65ac9d621b0cd3074d3bef27199ff78f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "pre-commit-hooks": {
-      "inputs": {
-        "flake-compat": "flake-compat_5",
-        "gitignore": "gitignore_3",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable_2"
-      },
-      "locked": {
-        "lastModified": 1718825512,
-        "narHash": "sha256-nz7idS/SZWcTUGJ+lOFL+eJayrL/LpkUiy7+FxThAh4=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "97c0dc865fe9a062c5970f4bcf55bb9e6028bcf5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "neorocks-nix": "neorocks-nix",
-        "nixpkgs": "nixpkgs_4",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "git-hooks": "git-hooks",
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {

--- a/lua/ltr/parser.lua
+++ b/lua/ltr/parser.lua
@@ -55,24 +55,4 @@ function Parser.parse_copy_directory_args(str_args)
   return copy_directories
 end
 
----@param interpreters_input string|nil
----@return lua_interpreter[]
-function Parser.parse_interpreter_input(interpreters_input)
-  local test_interpreters = {}
-  if interpreters_input then
-    for _, input in pairs(Parser.parse_list_args(interpreters_input)) do
-      if input == 'neovim-stable' then
-        table.insert(test_interpreters, 'neolua')
-      elseif input == 'neovim-nightly' then
-        table.insert(test_interpreters, 'neolua-nightly')
-      elseif input == 'lua' then
-        table.insert(test_interpreters, 'lua')
-      else
-        error('Test interpreter ' .. input .. ' not supported.')
-      end
-    end
-  end
-  return test_interpreters
-end
-
 return Parser

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -13,10 +13,10 @@ with final.stdenv; let
     ];
 
     propagatedBuildInputs = with pkgs.lua51Packages; [
-      # busted-nightly
       dkjson
       luafilesystem
       luarocks-build-rust-mlua
+      luarocks-build-treesitter-parser
     ];
 
     meta = {
@@ -31,8 +31,8 @@ with final.stdenv; let
   luarocks-tag-release-action = pkgs.writeShellApplication {
     name = "luarocks-tag-release-action";
     runtimeInputs = with pkgs; [
+      luarocks
       curl
-      neorocks
       luarocks-tag-release-action-wrapped
       unzip
       zip

--- a/spec/parser_spec.lua
+++ b/spec/parser_spec.lua
@@ -53,16 +53,4 @@ describe('Parser', function()
       'third',
     })
   end)
-  it('Parse interpreter input', function()
-    assert.same(Parser.parse_interpreter_input('neovim-stable'), { 'neolua' })
-    assert.same(Parser.parse_interpreter_input('neovim-nightly'), { 'neolua-nightly' })
-    assert.same(Parser.parse_interpreter_input('lua'), { 'lua' })
-    assert.same(
-      Parser.parse_interpreter_input([[
-        neovim-stable
-        neovim-nightly
-      ]]),
-      { 'neolua', 'neolua-nightly' }
-    )
-  end)
 end)


### PR DESCRIPTION
`neorocksTest` has dropped `neolua` in favour of `nlua`, so it will be incompatible after a flake.lock update.

Use [nvim-busted-action](https://github.com/marketplace/actions/nvim-busted-action) or [lua-busted](https://github.com/marketplace/actions/lua-busted) for tests instead!
