### PR TITLE
chore(gitignore): ignore .pre-commit-config.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ result
 /lua_modules
 /.luarocks
 .luarc.json
+.pre-commit-config.yaml


### PR DESCRIPTION
generated when starting the nix flake