### PR TITLE
ways to run luarocks-tag-release locally / easier way to test generated rockspec

### DIFF
--- a/bin/rockspec-generator-cli.lua
+++ b/bin/rockspec-generator-cli.lua
@@ -1,0 +1,24 @@
+local json = require('dkjson')
+
+json.decode(github_event_data)
+
+package_name = arg[0]
+dependencies = arg[1]
+rockspect_template = arg[1]
+
+  local rockspec = require('ltr.rockspec').generate(package_name, modrev, specrev, rockspec_template, {
+    ref_type = args.ref_type,
+    git_server_url = args.git_server_url,
+    github_repo = args.github_repo,
+    license = args.license,
+    git_ref = args.git_ref,
+    summary = args.summary,
+    detailed_description_lines = args.detailed_description_lines,
+    dependencies = args.dependencies,
+    test_dependencies = args.test_dependencies,
+    labels = args.labels,
+    copy_directories = args.copy_directories,
+    repo_name = args.repo_name,
+    github_event_tbl = github_event_tbl,
+  })
+

--- a/bin/rockspec-generator-cli.lua
+++ b/bin/rockspec-generator-cli.lua
@@ -6,19 +6,18 @@ package_name = arg[0]
 dependencies = arg[1]
 rockspect_template = arg[1]
 
-  local rockspec = require('ltr.rockspec').generate(package_name, modrev, specrev, rockspec_template, {
-    ref_type = args.ref_type,
-    git_server_url = args.git_server_url,
-    github_repo = args.github_repo,
-    license = args.license,
-    git_ref = args.git_ref,
-    summary = args.summary,
-    detailed_description_lines = args.detailed_description_lines,
-    dependencies = args.dependencies,
-    test_dependencies = args.test_dependencies,
-    labels = args.labels,
-    copy_directories = args.copy_directories,
-    repo_name = args.repo_name,
-    github_event_tbl = github_event_tbl,
-  })
-
+local rockspec = require('ltr.rockspec').generate(package_name, modrev, specrev, rockspec_template, {
+  ref_type = args.ref_type,
+  git_server_url = args.git_server_url,
+  github_repo = args.github_repo,
+  license = args.license,
+  git_ref = args.git_ref,
+  summary = args.summary,
+  detailed_description_lines = args.detailed_description_lines,
+  dependencies = args.dependencies,
+  test_dependencies = args.test_dependencies,
+  labels = args.labels,
+  copy_directories = args.copy_directories,
+  repo_name = args.repo_name,
+  github_event_tbl = github_event_tbl,
+})

--- a/bin/rockspec-generator-json.lua
+++ b/bin/rockspec-generator-json.lua
@@ -1,31 +1,69 @@
 #!/usr/bin/env lua
 local json = require('dkjson')
 
-json.decode(github_event_data)
+local input = io.stdin:read('*all')
+-- print('You entered: ' .. input)
 
-local input = io.stdin:read("*all")
-print("You entered: " .. input)
+meta = json.decode(input)
 
-package_name = input.name
-dependencies = input.dependencies
-license = input.license
+-- split after the
+package_name = meta.shorthand
+dependencies = meta.dependencies
+license = meta.license
+summary = meta.summary
+-- server_url =
+meta.repo_name = package_name
+meta.github_repo = meta.name
+meta.git_ref = 'main' -- TODO adjust
+meta.detailed_description_lines = ''
+meta.copy_directories = meta.extra_directories
+meta.labels = { 'neovim' }
+meta.test_dependencies = {}
 
+-- TODO split
+-- meta.dependencies = meta.dependencies
+meta.git_server_url = 'https://github.com'
+-- meta["github_repo"] = "lol"
+-- print(meta.github_repo)
+
+local result = {}
+-- if dependencies is empty then we
+-- for line in string.gmatch(meta.dependencies .. "\n", "(.-)\n") do
+--     table.insert(result, line);
+-- end
+
+meta.dependencies = result
+-- print(meta.dependencies)
+
+local rockspec_template_file_path = './resources/rockspec.template'
+-- rockspec_template_file_path
+local rockspec_template_fd =
+  assert(io.open(rockspec_template_file_path, 'r'), 'Could not open ' .. rockspec_template_file_path)
+local rockspec_template = rockspec_template_fd:read('*a')
+
+local specrev = 1
+local modrev = 1
 local rockspec = require('ltr.rockspec').generate(
-  package_name, modrev, specrev, rockspec_template,
-    {
-    ref_type = args.ref_type,
-    git_server_url = args.git_server_url,
-    github_repo = args.github_repo,
-    license = args.license,
-    git_ref = args.git_ref,
-    summary = args.summary,
-    detailed_description_lines = args.detailed_description_lines,
-    dependencies = args.dependencies,
-    test_dependencies = args.test_dependencies,
-    labels = args.labels,
-    copy_directories = args.copy_directories,
-    repo_name = args.repo_name,
-    github_event_tbl = github_event_tbl,
-  })
+  package_name,
+  modrev,
+  specrev,
+  rockspec_template,
+  meta
+  --   {
+  --   -- ref_type = args.ref_type,
+  --   -- git_server_url = args.git_server_url,
+  --   -- github_repo = args.github_repo,
+  --   license = license,
+  --   -- git_ref = args.git_ref,
+  --   summary = summary,
+  --   -- detailed_description_lines = args.detailed_description_lines,
+  --   -- dependencies = args.dependencies,
+  --   -- test_dependencies = args.test_dependencies,
+  --   -- labels = args.labels,
+  --   -- copy_directories = args.copy_directories,
+  --   -- repo_name = args.repo_name,
+  --   github_event_tbl = meta,
+  -- }
+)
 
-
+print(rockspec)

--- a/bin/rockspec-generator-json.lua
+++ b/bin/rockspec-generator-json.lua
@@ -1,0 +1,31 @@
+#!/usr/bin/env lua
+local json = require('dkjson')
+
+json.decode(github_event_data)
+
+local input = io.stdin:read("*all")
+print("You entered: " .. input)
+
+package_name = input.name
+dependencies = input.dependencies
+license = input.license
+
+local rockspec = require('ltr.rockspec').generate(
+  package_name, modrev, specrev, rockspec_template,
+    {
+    ref_type = args.ref_type,
+    git_server_url = args.git_server_url,
+    github_repo = args.github_repo,
+    license = args.license,
+    git_ref = args.git_ref,
+    summary = args.summary,
+    detailed_description_lines = args.detailed_description_lines,
+    dependencies = args.dependencies,
+    test_dependencies = args.test_dependencies,
+    labels = args.labels,
+    copy_directories = args.copy_directories,
+    repo_name = args.repo_name,
+    github_event_tbl = github_event_tbl,
+  })
+
+

--- a/flake.nix
+++ b/flake.nix
@@ -95,10 +95,13 @@
           (with pkgs; [
             lua-language-server
             luarocks
+            luaPackages.dkjson
+            lua
           ])
           ++ self.checks.${system}.formatting.enabledPackages;
         shellHook = ''
           ${self.checks.${system}.formatting.shellHook}
+          export LUA_PATH="lua/?.lua;$LUA_PATH"
         '';
       };
     in {

--- a/lua/ltr/rockspec_generator.lua
+++ b/lua/ltr/rockspec_generator.lua
@@ -1,0 +1,22 @@
+local M = {}
+
+function M.generate_rockspec()
+  local rockspec = rockspec_template
+    :gsub('$git_ref', meta.git_ref)
+    :gsub('$modrev', modrev)
+    :gsub('$specrev', specrev)
+    :gsub('$repo_url', repo_url)
+    :gsub('$archive_dir_suffix', archive_dir_suffix)
+    :gsub('$package', package_name)
+    :gsub('$summary', escape_quotes(meta.summary))
+    :gsub('$detailed_description', mk_lua_multiline_str(meta.detailed_description_lines))
+    :gsub('$dependencies', mk_lua_list_string(meta.dependencies))
+    :gsub('$test_dependencies', mk_lua_list_string(meta.test_dependencies))
+    :gsub('$labels', mk_lua_list_string(meta.labels))
+    :gsub('$homepage', homepage)
+    :gsub('$license', license)
+    :gsub('$copy_directories', mk_lua_list_string(meta.copy_directories))
+    :gsub('$repo_name', meta.repo_name)
+end
+
+return M

--- a/luarocks-tag-release-scm-1.rockspec
+++ b/luarocks-tag-release-scm-1.rockspec
@@ -11,6 +11,7 @@ description = {
 
 dependencies = {
   'lua >= 5.1',
+  'argparse',
   'dkjson',
   'luafilesystem',
 }


### PR DESCRIPTION
when I tried to add a plugin on NURR, I worried it wouldn't work (because it generated or needed C libraries etc and it was not possible to see the generated rockspec: "Push and prey". I would like to be able to see the generated rockspec before merging and I find it hard to run the action locally.

I quickly hacked something to be able to generate the rockspec bypassing the github action:
 `jq '.plugins[] | select(.name == nvim-telescope/telescope-fzf-native.nvim)' ~/nurr/plugins.json | ~/luarocks-tag-release/bin/rockspec-generator-json.lua`.
 
 I imagined 2 new executables:
- `rockspec-generator-json`to generate a rockspec for nurr. 
- `rockspec-generator-cli` that one could run from cli with an argparse interface, aka `rockspec-generator-cli --name toto --version 0.1 --dependency=plenary.nvim --dependency=nui.nvim`. 

What is your opinion on that ? is it something worth pursuing ? 