### PR TITLE
feat: explicit overriding of url

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: "The name of the your package"
     required: true
     default: ${{ github.event.repository.name }}
+  repository_url:
+    description: "The name of the your package"
+    required: true
+    default: ${{ env.GIT_SERVER_URL_OVERRIDE or env.GITHUB_SERVER_URL }}
   version:
     description: |
       The version of your package. Uses the git tag by default (if one exists).
@@ -76,6 +80,7 @@ runs:
       env:
         INPUT_NAME: ${{ inputs.name }}
         INPUT_VERSION: ${{ inputs.version }}
+        INPUT_REPOSITORY: ${{ inputs.repository_url }}
         INPUT_SPECREV: ${{ inputs.specrev }}
         INPUT_DEPENDENCIES: ${{ inputs.dependencies }}
         INPUT_TEST_DEPENDENCIES: ${{ inputs.test_dependencies }}

--- a/bin/luarocks-tag-release-action.lua
+++ b/bin/luarocks-tag-release-action.lua
@@ -23,7 +23,7 @@ local repo_name = assert(
   ]]
 )
 
-local git_server_url = os.getenv('GIT_SERVER_URL_OVERRIDE') or getenv_or_err('GITHUB_SERVER_URL')
+local git_server_url = getenv_or_err('INPUT_REPOSITORY')
 
 local is_pull_request = getenv_or_empty('GITHUB_EVENT_NAME') == 'pull_request'
 


### PR DESCRIPTION
my PR at https://github.com/nvim-neorocks/nurr/pull/33 fails because the generated URL is 
`local repo_url = 'https://github.com/https://git.sr.ht/~whynothugo/lsp_lines.nvim'`.
It's apparently already possible to override the default url via GIT_SERVER_URL_OVERRIDE but making it an explicit input is easier to discover ?